### PR TITLE
Updated node version for ui and backend containers

### DIFF
--- a/server/Dockerfile.express
+++ b/server/Dockerfile.express
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:16.20.2-buster-slim
+FROM --platform=linux/amd64 node:20.15.0-buster-slim
 WORKDIR /usr/src/app
 ARG PORT
 ARG DB_CONNECTION_STRING

--- a/ui/Dockerfile.ui
+++ b/ui/Dockerfile.ui
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:16.20.2-buster-slim
+FROM --platform=linux/amd64 node:20.15.0-buster-slim
 WORKDIR /usr/src/app
 COPY ./package*.json ./
 RUN npm install 


### PR DESCRIPTION
Updated Node version to 20.15.0 (LTS) to unblock @ptrodion in newer eslint version configuration